### PR TITLE
feat!: index_keys instead of after_9_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Just press the leader_key set on setup and follow you heart. (Is that easy)
 		quit = "q",
   },
   leader_key = ";",
-  after_9_keys = "zxcbnmZXVBNM,afghjklAFGHJKLwrtyuiopWRTYUIOP", -- Please, don't pin more than 9 XD,
+  index_keys = "123456789zxcbnmZXVBNM,afghjklAFGHJKLwrtyuiopWRTYUIOP", -- keys mapped to bookmark index, i.e. 1st bookmark will be accessible by 1, and 12th - by c
   save_key = function()
     return vim.loop.cwd() -- we use the cwd as the context from the bookmarks.  You can change it for anything you want.
   end,

--- a/lua/arrow/init.lua
+++ b/lua/arrow/init.lua
@@ -33,7 +33,7 @@ function M.setup(opts)
 	config.setState("leader_key", leader_key)
 	config.setState("always_show_path", opts.always_show_path or false)
 	config.setState("show_icons", opts.show_icons)
-	config.setState("after_9_keys", opts.after_9_keys or "zxcbnmZXVBNM,afghjklAFGHJKLwrtyuiopWRTYUIOP")
+	config.setState("index_keys", opts.index_keys or "123456789zxcbnmZXVBNM,afghjklAFGHJKLwrtyuiopWRTYUIOP")
 	config.setState("hide_handbook", opts.hide_handbook or false)
 
 	config.setState("save_key", opts.save_key or function()

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -8,7 +8,7 @@ local function show_right_index(index)
 	if index < 10 then
 		return index
 	else
-		return config.getState("after_9_keys"):sub(index - 9, index - 9)
+		return config.getState("index_keys"):sub(index, index)
 	end
 end
 

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -106,9 +106,7 @@ local function renderBuffer(buffer)
 	for i, fileName in ipairs(formattedFleNames) do
 		local displayIndex = i
 
-		if i > 9 then
-			displayIndex = config.getState("after_9_keys"):sub(i - 9, i - 9)
-		end
+		displayIndex = config.getState("index_keys"):sub(i, i)
 
 		vim.api.nvim_buf_add_highlight(buf, -1, "ArrowDeleteMode", i + 3, 0, -1)
 


### PR DESCRIPTION
I personally don't like using numbers to access things, but at the moment arrow.nvim doesn't allow to ditch them and use a different set of keys entirely.

This PR replaces `after_9_keys` option with `index_keys` so you can redefine your keys to index bookmarks entirely, i.e. using `"afg..." you can access first three entries via a, f and g accordingly.

By default it will still use 1-9.