### PR TITLE
fix highlight in 0.10

### DIFF
--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -244,7 +244,7 @@ local function render_highlights(buffer)
 
 	if config.getState("show_icons") then
 		for k, v in pairs(to_highlight) do
-			vim.api.nvim_buf_add_highlight(menuBuf, -1, v, k, 7, 8)
+			vim.api.nvim_buf_add_highlight(menuBuf, -1, v, k, 5, 8)
 		end
 	end
 


### PR DESCRIPTION
from nvim_buf_add_highlight' document, start_col and end_col is using byte index, for some reason I  don't understand this is broken in 0.10.

broken highlight in 0.10:
<img width="376" alt="截屏2024-03-14 07 40 59" src="https://github.com/otavioschwanck/arrow.nvim/assets/97848247/68542646-b946-4c28-ab5d-fcf3ade9dd65">

I use this function to check byte sequence
```lua
	local function printByteSequence(str)
		for i = 1, #str do
			local c = str:sub(i, i)
			print("'" .. c .. "' byte sequence: " .. string.byte(c, 1, #c))
		end
	end

	if config.getState("show_icons") then
		for k, v in pairs(to_highlight) do
			local line = vim.api.nvim_buf_get_lines(menuBuf, k, k + 1, false)[1]
			-- __AUTO_GENERATED_PRINT_VAR_START__
			print([==[render_highlights#if#for line:]==], vim.inspect(line)) -- __AUTO_GENERATED_PRINT_VAR_END__
			printByteSequence(line)
			vim.api.nvim_buf_add_highlight(menuBuf, -1, v, k, 7, 8)
		end
	end
```
the result is 
```txt
render_highlights#if#for line: "   2  statusline.lua"
    ' ' byte sequence: 32
    ' ' byte sequence: 32
    ' ' byte sequence: 32
    '2' byte sequence: 50
    ' ' byte sequence: 32
    'î' byte sequence: 238
    '' byte sequence: 152
    ' ' byte sequence: 160
    ' ' byte sequence: 32
    's' byte sequence: 115
    't' byte sequence: 116
    'a' byte sequence: 97
    't' byte sequence: 116
    'u' byte sequence: 117
    's' byte sequence: 115
    'l' byte sequence: 108
    'i' byte sequence: 105
    'n' byte sequence: 110
    'e' byte sequence: 101
    '.' byte sequence: 46
    'l' byte sequence: 108
    'u' byte sequence: 117
    'a' byte sequence: 97
```
So, range[5,8] is the icon, change [7,8] to [5,8] fix icon highlight in 0.10.