### PR TITLE
feat: add git_root save key support

### DIFF
--- a/lua/arrow/git.lua
+++ b/lua/arrow/git.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 local config = require("arrow.config")
 
 function M.get_git_branch()

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -67,7 +67,7 @@ end
 function M.toggle(filename)
 	git.refresh_git_branch()
 
-	filename = filename or utils.get_path_for("%")
+	filename = filename or utils.get_current_buffer_path()
 
 	local index = M.is_saved(filename)
 	if index then
@@ -126,7 +126,7 @@ end
 function M.next()
 	git.refresh_git_branch()
 
-	local current_index = M.is_saved(utils.get_path_for("%"))
+	local current_index = M.is_saved(utils.get_current_buffer_path())
 	local next_index
 
 	if current_index and current_index < #vim.g.arrow_filenames then
@@ -141,7 +141,7 @@ end
 function M.previous()
 	git.refresh_git_branch()
 
-	local current_index = M.is_saved(utils.get_path_for("%"))
+	local current_index = M.is_saved(utils.get_current_buffer_path())
 	local previous_index
 
 	if current_index and current_index == 1 then

--- a/lua/arrow/save_keys.lua
+++ b/lua/arrow/save_keys.lua
@@ -5,7 +5,13 @@ function M.cwd()
 end
 
 function M.git_root()
-	return vim.fn.system("git rev-parse --show-toplevel | tr -d '\n'")
+	local git_root = vim.fn.system("git rev-parse --show-toplevel 2>&1")
+
+	if vim.v.shell_error == 0 then
+		return git_root:gsub("\n$", "")
+	end
+
+	return M.cwd()
 end
 
 return M

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -18,7 +18,7 @@ function M.in_on_arrow_file()
 	if config.getState("global_bookmarks") == true then
 		filename = vim.fn.expand("%:p")
 	else
-		filename = utils.get_path_for("%")
+		filename = utils.get_current_buffer_path()
 	end
 
 	return persist.is_saved(filename)

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -412,7 +412,7 @@ function M.openMenu()
 	if config.getState("global_bookmarks") == true then
 		filename = vim.fn.expand("%:p")
 	else
-		filename = utils.get_path_for("%")
+		filename = utils.get_current_buffer_path()
 	end
 
 	local menuBuf = createMenuBuffer(filename)
@@ -435,14 +435,14 @@ function M.openMenu()
 
 	if separate_save_and_remove then
 		vim.keymap.set("n", mappings.toggle, function()
-			filename = filename or utils.get_path_for("%")
+			filename = filename or utils.get_current_buffer_path()
 
 			persist.save(filename)
 			closeMenu()
 		end, menuKeymapOpts)
 
 		vim.keymap.set("n", mappings.remove, function()
-			filename = filename or utils.get_path_for("%")
+			filename = filename or utils.get_current_buffer_path()
 
 			persist.remove(filename)
 			closeMenu()

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -332,8 +332,7 @@ function M.openFile(fileNumber, previousFile)
 		end
 
 		closeMenu()
-
-		action(fileName, vim.b.filename)
+		action(config.getState('save_key')() .. '/' .. fileName, vim.b.filename)
 	end
 end
 

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -30,18 +30,17 @@ function M.join_two_arrays(tableA, tableB)
 	return newTable
 end
 
-function M.get_path_for(buffer)
-	local bufname = vim.fn.bufname(buffer)
+function M.get_current_buffer_path()
+	local absolute_buffer_path = vim.fn.expand('%:p')
 
 	local save_key = config.getState("save_key")()
+	local escaped_save_key = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
 
-	local escaped_cwd = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
-
-	if bufname:find("^" .. escaped_cwd .. "/") then
-		local relative_path = bufname:gsub("^" .. escaped_cwd .. "/", "")
+	if absolute_buffer_path:find("^" .. escaped_save_key .. "/") then
+		local relative_path = absolute_buffer_path:gsub("^" .. escaped_save_key .. "/", "")
 		return relative_path
 	else
-		return bufname
+		return absolute_buffer_path
 	end
 end
 

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local config = require("arrow.config")
+
 function M.join_two_keys_tables(tableA, tableB)
 	local newTable = {}
 
@@ -31,9 +33,9 @@ end
 function M.get_path_for(buffer)
 	local bufname = vim.fn.bufname(buffer)
 
-	local cwd = vim.fn.getcwd()
+	local save_key = config.getState("save_key")()
 
-	local escaped_cwd = cwd:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
+	local escaped_cwd = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
 
 	if bufname:find("^" .. escaped_cwd .. "/") then
 		local relative_path = bufname:gsub("^" .. escaped_cwd .. "/", "")


### PR DESCRIPTION
### Overview

This PR introduces proper handling of file paths when using the `save_key = git_root` option.

### Key changes

- Open a file by always prefixing the relative file path with either the `cwd` or `git_root`.
- Make the `get_path_for` utility either remove the `cwd` or `git_root` before saving the path.
- Fallback to the current working directory when unable to parse a top-level git path.
- Change `get_path_for` utility to `get_current_buffer_path` and make it consistent by expanding the absolute path.

This closes #21.