### PR TITLE
feat(edit): add relative_path option to arrow config

### DIFF
--- a/lua/arrow/init.lua
+++ b/lua/arrow/init.lua
@@ -67,6 +67,7 @@ function M.setup(opts)
 	config.setState("hide_handbook", opts.hide_handbook or false)
 	config.setState("separate_by_branch", opts.separate_by_branch or false)
 	config.setState("global_bookmarks", opts.global_bookmarks or false)
+	config.setState("relative_path", opts.relative_path or false)
 	config.setState("separate_save_and_remove", opts.separate_save_and_remove or false)
 
 	config.setState("save_key", save_keys[opts.save_key] or save_keys.cwd)

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -167,6 +167,15 @@ function M.open_cache_file()
 		cache_content = vim.fn.readfile(cache_path)
 	end
 
+	if config.getState("relative_path") == true then
+		for i, line in ipairs(cache_content) do
+			if not line:match("^%./") and not utils.string_contains_whitespace(line) and #cache_content[i] > 1 then
+				cache_content[i] = "./" .. line
+				break
+			end
+		end
+	end
+
 	local bufnr = vim.api.nvim_create_buf(false, true)
 
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, cache_content)
@@ -196,14 +205,14 @@ function M.open_cache_file()
 	vim.keymap.set(
 		"n",
 		config.getState("leader_key"),
-		function() end,
+		close_buffer,
 		{ noremap = true, silent = true, buffer = bufnr }
 	)
 
 	vim.keymap.set("n", "<CR>", function()
 		local line = vim.api.nvim_get_current_line()
 
-		vim.api.nvim_win_close(winid, { force = true })
+		vim.api.nvim_win_close(winid, true)
 		vim.cmd(":edit " .. line)
 	end, { noremap = true, silent = true, buffer = bufnr })
 

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -44,4 +44,8 @@ function M.get_current_buffer_path()
 	end
 end
 
+function M.string_contains_whitespace(str)
+	return string.match(str, "%s") ~= nil
+end
+
 return M


### PR DESCRIPTION
Hello everyone! 

This commit introduces a new setup option: ``relative_path``, which when enabled, will automatically prepend a ``./`` when adding a new item in arrow (either by navigating to it and using the ``toggle`` mapping, or by inserting it into the ``edit`` buffer). I added a couple of simple conditions to it, like skipping any line which contains any whitespace, or any line that already starts with a ``./`` or the line being empty, which should improve the usability.

This is useful particularly when it's used alongside with [``cmp-path``](https://github.com/hrsh7th/cmp-path) because it allows the user to easily add any file, without having to fuzzy find it and navigate there first using for example Telescope (or having to guess/remember the proper location of it).

On top of that, I added a simple remap to close the ``edit`` window (buffer) by pressing the ``leader_key``. 

Thanks for making this awesome plugin, Let me know if you have any questions!