### PR TITLE
Feat/per buffer use extmark to track lines

### DIFF
--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -4,7 +4,17 @@ local config = require("arrow.config")
 local utils = require("arrow.utils")
 local json = require("arrow.json")
 
+local ns = vim.api.nvim_create_namespace("arrow_bookmarks")
 M.local_bookmarks = {}
+
+vim.api.nvim_create_autocmd("VimLeavePre", {
+	callback = function()
+		for bufnr, _ in pairs(M.local_bookmarks) do
+			M.update(bufnr)
+			M.sync_buffer_bookmarks(bufnr)
+		end
+	end,
+})
 
 local function save_key(filename)
 	return utils.normalize_path_to_filename(filename)
@@ -37,7 +47,17 @@ function M.load_buffer_bookmarks(bufnr)
 		f:close()
 
 		local success, result = pcall(json.decode, content)
-
+		if result ~= nil then
+			for _, res in ipairs(result) do
+				local line = res.line
+				local id = vim.api.nvim_buf_set_extmark(bufnr, ns, line - 1, -1, {
+					sign_text = "󰧌",
+					sign_hl_group = "BookmarkSign",
+					hl_mode = "combine",
+				})
+				res.ext_id = id
+			end
+		end
 		if success then
 			M.local_bookmarks[bufnr] = result
 		else
@@ -61,8 +81,11 @@ function M.sync_buffer_bookmarks(bufnr)
 	local file = io.open(path, "w")
 
 	if file then
-		file:write(json.encode(M.local_bookmarks[bufnr]))
-
+		if M.local_bookmarks[bufnr] == nil or #M.local_bookmarks[bufnr] == 0 then
+			file:write("[]")
+		else
+			file:write(json.encode(M.local_bookmarks[bufnr]))
+		end
 		return true
 	end
 
@@ -93,7 +116,7 @@ function M.remove(index, bufnr)
 	if M.local_bookmarks[bufnr][index] == nil then
 		return
 	end
-
+	vim.api.nvim_buf_del_extmark(bufnr, ns, M.local_bookmarks[bufnr][index].ext_id)
 	table.remove(M.local_bookmarks[bufnr], index)
 
 	M.sync_buffer_bookmarks(bufnr)
@@ -103,8 +126,23 @@ function M.clear(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 
 	M.local_bookmarks[bufnr] = {}
-
+	vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 	M.sync_buffer_bookmarks(bufnr)
+end
+
+function M.update(bufnr)
+	bufnr = bufnr or vim.api.nvim_get_current_buf()
+	local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns, { 0, 0 }, { -1, -1 }, {})
+	if M.local_bookmarks[bufnr] ~= nil then
+		for _, mark in ipairs(M.local_bookmarks[bufnr]) do
+			for _, extmark in ipairs(extmarks) do
+				local extmark_id, extmark_row, _ = unpack(extmark)
+				if mark.ext_id == extmark_id and mark.line ~= extmark_row then
+					mark.line = extmark_row + 1
+				end
+			end
+		end
+	end
 end
 
 function M.save(bufnr, line_nr, col_nr)
@@ -114,9 +152,16 @@ function M.save(bufnr, line_nr, col_nr)
 		M.local_bookmarks[bufnr] = {}
 	end
 
+	local id = vim.api.nvim_buf_set_extmark(bufnr, ns, line_nr - 1, -1, {
+		sign_text = "󰧌",
+		sign_hl_group = "BookmarkSign",
+		hl_mode = "combine",
+	})
+
 	local data = {
 		line = line_nr,
 		col = col_nr,
+		ext_id = id,
 	}
 
 	if not (M.is_saved(bufnr, data)) then

--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -137,7 +137,7 @@ function M.update(bufnr)
 		for _, mark in ipairs(M.local_bookmarks[bufnr]) do
 			for _, extmark in ipairs(extmarks) do
 				local extmark_id, extmark_row, _ = unpack(extmark)
-				if mark.ext_id == extmark_id and mark.line ~= extmark_row then
+				if mark.ext_id == extmark_id and mark.line ~= extmark_row + 1 then
 					mark.line = extmark_row + 1
 				end
 			end

--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -86,6 +86,7 @@ function M.sync_buffer_bookmarks(bufnr)
 		else
 			file:write(json.encode(M.local_bookmarks[bufnr]))
 		end
+		file:flush()
 		return true
 	end
 

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -107,10 +107,15 @@ local function closeMenu(actions_buffer)
 end
 
 local function go_to_bookmark(bookmark)
-	vim.api.nvim_win_set_cursor(0, { bookmark.line, bookmark.col })
+	vim.cmd("normal! m'")
+	local win_height = vim.fn.winheight(0)
+	local top_line = vim.fn.line("w0")
 
-	-- centralize cursor
-	vim.cmd("normal! zz")
+	vim.api.nvim_win_set_cursor(0, { bookmark.line, bookmark.col })
+	if bookmark.line < top_line or bookmark.line >= top_line + win_height then
+		-- centralize cursor
+		vim.cmd("normal! zz")
+	end
 end
 
 local function toggle_delete_mode()


### PR DESCRIPTION
This track system works nicely thanks to extmarks's tracking nature, it is really complicated in vscode to track bookmarks lines.
Some ideas: 
1. When users select bookmarks, their eyes are usually placed on the cursor line, so highlighting the cursor position like portal may be a better choice. 
2. We can add a setting to automatically add the current file when adding a bookmark(if the file does not added yet), and show bookmarks numbers after filenames, then it becomes a natural tree representation.
3. The window layout may be more intelligent. If there is not enough space, compress the width and display two columns. If it is even not enough, compress the height.
4. Window title maybe can used for displaying a note(though I'm lazy to add notes).

It works very good by far, and IMO better than other bookmark plugins which typically use Telescope to select entries, there are no syntax highlighting at a glance and have more mental overhead, that's why users choose arrow instead of fuzzy find files😓