### PR TITLE
Add support for multiple buffers in the statusline

### DIFF
--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -8,8 +8,6 @@ local function show_right_index(index)
 	return config.getState("index_keys"):sub(index, index)
 end
 
-end
-
 function M.is_on_arrow_file(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
 

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -23,7 +23,7 @@ function M.is_on_arrow_file(bufnr)
 end
 
 function M.text_for_statusline(index)
-	index = index or M.in_on_arrow_file()
+    index = index or M.is_on_arrow_file()
 
 	if index then
 		return show_right_index(index)
@@ -33,7 +33,7 @@ function M.text_for_statusline(index)
 end
 
 function M.text_for_statusline_with_icons()
-	local index = M.in_on_arrow_file()
+    local index = M.is_on_arrow_file()
 
 	if index then
 		return "󱡁 " .. show_right_index(index)

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -8,20 +8,20 @@ local function show_right_index(index)
 	return config.getState("index_keys"):sub(index, index)
 end
 
-function M.is_on_arrow_file()
-	return M.in_on_arrow_file()
 end
 
-function M.in_on_arrow_file()
-	local filename
+function M.is_on_arrow_file(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
 
-	if config.getState("global_bookmarks") == true then
-		filename = vim.fn.expand("%:p")
-	else
-		filename = utils.get_current_buffer_path()
-	end
+    local file_path
+    local bufname = vim.fn.bufname(bufnr)
+    if config.getState("global_bookmarks") == true then
+        file_path = vim.fn.expand(bufname .. ":p")
+    else
+        file_path = utils.get_buffer_path(bufnr)
+    end
 
-	return persist.is_saved(filename)
+    return persist.is_saved(file_path)
 end
 
 function M.text_for_statusline(index)

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -14,7 +14,7 @@ function M.is_on_arrow_file(bufnr)
     local file_path
     local bufname = vim.fn.bufname(bufnr)
     if config.getState("global_bookmarks") == true then
-        file_path = vim.fn.fnamemode(bufname, ":p")
+        file_path = vim.fn.fnamemodify(bufname, ":p")
     else
         file_path = utils.get_buffer_path(bufnr)
     end

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -22,8 +22,8 @@ function M.is_on_arrow_file(bufnr)
     return persist.is_saved(file_path)
 end
 
-function M.text_for_statusline(index)
-    index = index or M.is_on_arrow_file()
+function M.text_for_statusline(bufnr)
+    local index = M.is_on_arrow_file(bufnr)
 
 	if index then
 		return show_right_index(index)
@@ -32,8 +32,8 @@ function M.text_for_statusline(index)
 	end
 end
 
-function M.text_for_statusline_with_icons()
-    local index = M.is_on_arrow_file()
+function M.text_for_statusline_with_icons(bufnr)
+    local index = M.is_on_arrow_file(bufnr)
 
 	if index then
 		return "󱡁 " .. show_right_index(index)

--- a/lua/arrow/statusline.lua
+++ b/lua/arrow/statusline.lua
@@ -14,7 +14,7 @@ function M.is_on_arrow_file(bufnr)
     local file_path
     local bufname = vim.fn.bufname(bufnr)
     if config.getState("global_bookmarks") == true then
-        file_path = vim.fn.expand(bufname .. ":p")
+        file_path = vim.fn.fnamemode(bufname, ":p")
     else
         file_path = utils.get_buffer_path(bufnr)
     end

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -31,17 +31,22 @@ function M.join_two_arrays(tableA, tableB)
 end
 
 function M.get_current_buffer_path()
-	local absolute_buffer_path = vim.fn.expand("%:p")
+    return M.get_buffer_path(vim.api.nvim_get_current_buf())
+end
 
-	local save_key = config.getState("save_key_cached")
-	local escaped_save_key = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
+function M.get_buffer_path(bufnr)
+    local bufname = vim.fn.bufname(bufnr)
+    local absolute_buffer_path = vim.fn.expand(bufname .. ":p")
 
-	if absolute_buffer_path:find("^" .. escaped_save_key .. "/") then
-		local relative_path = absolute_buffer_path:gsub("^" .. escaped_save_key .. "/", "")
-		return relative_path
-	else
-		return absolute_buffer_path
-	end
+    local save_key = config.getState("save_key_cached")
+    local escaped_save_key = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
+
+    if absolute_buffer_path:find("^" .. escaped_save_key .. "/") then
+        local relative_path = absolute_buffer_path:gsub("^" .. escaped_save_key .. "/", "")
+        return relative_path
+    else
+        return absolute_buffer_path
+    end
 end
 
 function M.string_contains_whitespace(str)

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -36,7 +36,7 @@ end
 
 function M.get_buffer_path(bufnr)
     local bufname = vim.fn.bufname(bufnr)
-    local absolute_buffer_path = vim.fn.expand(bufname .. ":p")
+    local absolute_buffer_path = vim.fn.fnamemodify(bufname, ":p")
 
     local save_key = config.getState("save_key_cached")
     local escaped_save_key = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")


### PR DESCRIPTION
I noticed that the status line implementation only uses the current buffer, this doent work for me as I am using incline to have multiple statuslines for all of the windows I have active. Additionally, since this operates on the current buffer, it isnt visible in the statusline if you open telescope or some other floating window, sending the buffer number to operate on explicitly fixes that issue as well.

In this PR, I have added support so that you can send a bufnr to operate on, but if you leave it blank, it should work like it did before, and grab the current buffer instead, so not a breaking change.

Here is an image of how it looks now in my setup, with window 1, and 2 being added to arrow, and window 3 not being added, notice in the incline statusline that is top right in all of the windows that the arrow indicator is correct, and that it it still being drawn when telescope is open:

![image](https://github.com/otavioschwanck/arrow.nvim/assets/35811847/2896fb20-c24e-4aba-bb65-2adeb7bf76b6)
