### PR TITLE
treesitter-context integration

### DIFF
--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -8,15 +8,6 @@ local ns = vim.api.nvim_create_namespace("arrow_bookmarks")
 M.local_bookmarks = {}
 M.last_sync_bookmarks = {}
 
-vim.api.nvim_create_autocmd("VimLeavePre", {
-	callback = function()
-		for bufnr, _ in pairs(M.local_bookmarks) do
-			M.update(bufnr)
-			M.sync_buffer_bookmarks(bufnr)
-		end
-	end,
-})
-
 local function save_key(filename)
 	return utils.normalize_path_to_filename(filename)
 end

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -92,12 +92,11 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 	vim.api.nvim_win_set_config(win, { title = displayIndex .. " " .. extra_title })
 	vim.api.nvim_win_set_option(win, "number", true)
 	
-	if config.getState("per_buffer_config").treesitter_context ~= nil then
-		local ctx_config = config.getState("per_buffer_config").treesitter_context
+	local ctx_config = config.getState("per_buffer_config").treesitter_context
+	if ctx_config ~= nil and ctx_config.line_shift_down ~= nil then
 		local shift = ctx_config.line_shift_down
 
 		local win_view = vim.fn.winsaveview()
-
 		vim.api.nvim_win_set_option(win, "scrolloff", 0)
 		vim.fn.winrestview({ topline = win_view.topline - shift })
 
@@ -105,6 +104,7 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 		if not ok then
 			vim.notify("you don't have treesitter-context installed", vim.log.levels.WARN)
 		end
+
 		local context, context_lines = require("treesitter-context.context").get(buffer, win)
 		if context and #context > 0 then
 			vim.defer_fn(function()

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -100,7 +100,7 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 		vim.api.nvim_win_set_option(win, "scrolloff", 0)
 		vim.fn.winrestview({ topline = win_view.topline - shift })
 
-		local ok, _ = pcall(require, "nvim-treesitter")
+		local ok, _ = pcall(require, "treesitter-context")
 		if not ok then
 			vim.notify("you don't have treesitter-context installed", vim.log.levels.WARN)
 		end

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -106,9 +106,11 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 			vim.notify("you don't have treesitter-context installed", vim.log.levels.WARN)
 		end
 		local context, context_lines = require("treesitter-context.context").get(buffer, win)
-		vim.defer_fn(function()
-			require("treesitter-context.render").open(buffer, win, context, context_lines)
-		end, 10)
+		if context and #context > 0 then
+			vim.defer_fn(function()
+				require("treesitter-context.render").open(buffer, win, context, context_lines)
+			end, 10)
+		end
 	end
 
 	table.insert(preview_buffers, { buffer = buffer, win = win, index = index })


### PR DESCRIPTION
It looks like
with line_shift_down=2
<img width="1209" alt="截屏2024-04-11 03 49 41" src="https://github.com/otavioschwanck/arrow.nvim/assets/97848247/70db5706-55f2-49bd-8e2f-41c054af71fe">
with line_shift_down=1
<img width="1121" alt="截屏2024-04-11 03 50 43" src="https://github.com/otavioschwanck/arrow.nvim/assets/97848247/7479f227-f91f-4d7e-bd3e-de2a29398873">
with line_shift_down=0
<img width="1030" alt="截屏2024-04-11 03 50 59" src="https://github.com/otavioschwanck/arrow.nvim/assets/97848247/13119645-ffd6-4d39-afdc-61ed6e2a2e25">

the config option now is 
```lua
        per_buffer_config = {
            treesitter_context = {
                line_shift_down = 2, -- how many lines shift down from center, so cursor above will have actual code not influenced by context.
            },
            lines = 6,
        },
```
note: the zindex should be lower than context's window
Please try this branch to test it, we can make this option undocumented, test it for now and wait this to merge( I tried to make it work out of box, but our window opens too fast to determine bufnr in WinEnter autocmd).
https://github.com/nvim-treesitter/nvim-treesitter-context/pull/419


