### PR TITLE
fix: error when there's no `Cursor` highlight

### DIFF
--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -412,6 +412,7 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 	vim.api.nvim_create_autocmd("BufLeave", {
 		buffer = 0,
 		desc = "Disable Cursor",
+		once = true,
 		callback = function()
 			vim.cmd("highlight clear Cursor")
 

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -91,7 +91,7 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 	vim.api.nvim_win_set_cursor(win, { bookmark.line, 0 })
 	vim.api.nvim_win_set_config(win, { title = displayIndex .. " " .. extra_title })
 	vim.api.nvim_win_set_option(win, "number", true)
-	
+
 	local ctx_config = config.getState("per_buffer_config").treesitter_context
 	if ctx_config ~= nil and ctx_config.line_shift_down ~= nil then
 		local shift = ctx_config.line_shift_down
@@ -223,7 +223,6 @@ local function toggle_delete_mode(action_buffer)
 		local arrow_delete_mode = vim.api.nvim_get_hl_by_name("ArrowDeleteMode", true)
 
 		vim.api.nvim_set_hl(0, "FloatBorder", { fg = arrow_delete_mode.bg or "red" })
-		pcall(vim.api.nvim_set_hl, 0, "Cursor")
 	end
 
 	render_highlights(action_buffer)

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -297,12 +297,8 @@ end
 function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_window, index)
 	local actions_buffer = vim.api.nvim_create_buf(false, true)
 
-	local hl = vim.api.nvim_get_hl_by_name("Cursor", true)
-	hl.blend = 100
-
-	vim.opt.guicursor:append("a:Cursor/lCursor")
-
-	pcall(vim.api.nvim_set_hl, 0, "Cursor", hl)
+	vim.api.nvim_set_hl(0, "ArrowCursor", { bg = "#ffffff", blend = 100 })
+	vim.opt.guicursor:append("a:ArrowCursor/ArrowCursor")
 
 	local lines_count = config.getState("per_buffer_config").lines
 
@@ -414,20 +410,15 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 		desc = "Disable Cursor",
 		once = true,
 		callback = function()
-			vim.cmd("highlight clear Cursor")
-
 			close_preview_windows()
 
 			vim.schedule(function()
-				local old_hl = hl
-				old_hl.blend = 0
-				pcall(vim.api.nvim_set_hl, 0, "Cursor", old_hl)
-
 				if vim.api.nvim_buf_is_valid(actions_buffer) then
 					closeMenu(actions_buffer, call_buffer)
 				end
 
-				vim.opt.guicursor:remove("a:Cursor/lCursor")
+				vim.opt.guicursor:remove("a:ArrowCursor/ArrowCursor")
+				vim.cmd("highlight clear ArrowCursor")
 			end)
 		end,
 	})

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -539,6 +539,7 @@ function M.openMenu(bufnr)
 	vim.api.nvim_create_autocmd("BufLeave", {
 		buffer = 0,
 		desc = "Disable Cursor",
+		once = true,
 		callback = function()
 			current_index = 0
 

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -160,7 +160,7 @@ local function renderBuffer(buffer)
 	local lines = { "" }
 
 	local formattedFleNames = format_file_names(fileNames)
-	
+
 	to_highlight = {}
 	current_index = 0
 
@@ -530,11 +530,9 @@ function M.openMenu(bufnr)
 		render_highlights(menuBuf)
 	end, menuKeymapOpts)
 
-	local hl = vim.api.nvim_get_hl_by_name("Cursor", true)
-	hl.blend = 100
-
-	vim.opt.guicursor:append("a:Cursor/lCursor")
-	vim.api.nvim_set_hl(0, "Cursor", hl)
+	-- dumb color is needed for the highlight group to be applied
+	vim.api.nvim_set_hl(0, "ArrowCursor", { bg = "#ffffff", blend = 100 })
+	vim.opt.guicursor:append("a:ArrowCursor/ArrowCursor")
 
 	vim.api.nvim_create_autocmd("BufLeave", {
 		buffer = 0,
@@ -543,15 +541,8 @@ function M.openMenu(bufnr)
 		callback = function()
 			current_index = 0
 
-			vim.cmd("highlight clear Cursor")
-
-			vim.schedule(function()
-				local old_hl = hl
-				old_hl.blend = 0
-				pcall(vim.api.nvim_set_hl, 0, "Cursor", old_hl)
-
-				vim.opt.guicursor:remove("a:Cursor/lCursor")
-			end)
+			vim.opt.guicursor:remove("a:ArrowCursor/ArrowCursor")
+			vim.cmd("highlight clear ArrowCursor")
 		end,
 	})
 


### PR DESCRIPTION
Hi there! First of all, really thank you for this plugin. I never knew I needed it until I tried haha!

Since I notice that `arrow` fails when there's no such a highlight as `Cursor`. It happens because of the deprecated `nvim_get_hl_by_name` method. If there's no such a highlight, it just throws an error.

But! When I started fixing the error, I found a data leak in `BufLeave` autocmd. You can clearly see it if you open and close `arrow.nvim` 10 times and then check your autocmds by `:autocmd`. You'll see 10 `BufLeave` autocmds. I fixed it in the first commit.

Returning back to the original issue - I don't really see the reason overcomplicating in that place, but maybe I'm missing anything? I just created a dummy highlight and shadowed the original cursor highlight. When leaving a buffer, I just deleted the highlight and the cursor setting for it.

P.S. just noticed that in the `buffer_ui.lua` there're the same errors. Created fixes for those as well!