### PR TITLE
fix: cursor disappearance #48

### DIFF
--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -297,9 +297,6 @@ end
 function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_window, index)
 	local actions_buffer = vim.api.nvim_create_buf(false, true)
 
-	vim.api.nvim_set_hl(0, "ArrowCursor", { bg = "#ffffff", blend = 100 })
-	vim.opt.guicursor:append("a:ArrowCursor/ArrowCursor")
-
 	local lines_count = config.getState("per_buffer_config").lines
 
 	local width = math.ceil(vim.o.columns / 2)
@@ -405,20 +402,22 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 		end, menuKeymapOpts)
 	end
 
+	vim.api.nvim_set_hl(0, "ArrowCursor", { nocombine = true, blend = 100 })
+	vim.opt.guicursor:append("a:ArrowCursor/ArrowCursor")
+
 	vim.api.nvim_create_autocmd("BufLeave", {
 		buffer = 0,
 		desc = "Disable Cursor",
 		once = true,
 		callback = function()
 			close_preview_windows()
+			if vim.api.nvim_buf_is_valid(actions_buffer) then
+				closeMenu(actions_buffer, call_buffer)
+			end
 
+			vim.cmd("highlight clear ArrowCursor")
 			vim.schedule(function()
-				if vim.api.nvim_buf_is_valid(actions_buffer) then
-					closeMenu(actions_buffer, call_buffer)
-				end
-
 				vim.opt.guicursor:remove("a:ArrowCursor/ArrowCursor")
-				vim.cmd("highlight clear ArrowCursor")
 			end)
 		end,
 	})

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -530,8 +530,7 @@ function M.openMenu(bufnr)
 		render_highlights(menuBuf)
 	end, menuKeymapOpts)
 
-	-- dumb color is needed for the highlight group to be applied
-	vim.api.nvim_set_hl(0, "ArrowCursor", { bg = "#ffffff", blend = 100 })
+	vim.api.nvim_set_hl(0, "ArrowCursor", { nocombine = true, blend = 100 })
 	vim.opt.guicursor:append("a:ArrowCursor/ArrowCursor")
 
 	vim.api.nvim_create_autocmd("BufLeave", {
@@ -541,8 +540,10 @@ function M.openMenu(bufnr)
 		callback = function()
 			current_index = 0
 
-			vim.opt.guicursor:remove("a:ArrowCursor/ArrowCursor")
 			vim.cmd("highlight clear ArrowCursor")
+			vim.schedule(function()
+				vim.opt.guicursor:remove("a:ArrowCursor/ArrowCursor")
+			end)
 		end,
 	})
 

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -445,13 +445,16 @@ function M.openMenu(bufnr)
 
 	vim.keymap.set("n", config.getState("leader_key"), closeMenu, menuKeymapOpts)
 
-	vim.keymap.set("n", config.getState("buffer_leader_key"), function()
-		closeMenu()
+	local buffer_leader_key = config.getState("buffer_leader_key")
+	if buffer_leader_key then
+		vim.keymap.set("n", config.getState("buffer_leader_key"), function()
+			closeMenu()
 
-		vim.schedule(function()
-			require("arrow.buffer_ui").openMenu(call_buffer)
-		end)
-	end, menuKeymapOpts)
+			vim.schedule(function()
+				require("arrow.buffer_ui").openMenu(call_buffer)
+			end)
+		end, menuKeymapOpts)
+	end
 
 	vim.keymap.set("n", mappings.quit, closeMenu, menuKeymapOpts)
 	vim.keymap.set("n", mappings.edit, function()

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -447,7 +447,7 @@ function M.openMenu(bufnr)
 
 	local buffer_leader_key = config.getState("buffer_leader_key")
 	if buffer_leader_key then
-		vim.keymap.set("n", config.getState("buffer_leader_key"), function()
+		vim.keymap.set("n", buffer_leader_key, function()
 			closeMenu()
 
 			vim.schedule(function()


### PR DESCRIPTION
Only removes guicursor option on the next event loop cycle.

I had to move `closeMenu` call out of `vim.schedule` so that it worked. Could you please clarify that it doesn't break anything or any reason why it was inside `vim.schedule`? Seems to work perfectly on my machine.