### PR TITLE
dos: add missing comma that breaks the packer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ return {
 use { 'otavioschwanck/arrow.nvim', config = function()
   require('arrow').setup({
     show_icons = true,
-    leader_key = ';' -- Recommended to be a single key
+    leader_key = ';', -- Recommended to be a single key
     buffer_leader_key = 'm', -- Per Buffer Mappings
   })
 end }


### PR DESCRIPTION
This PR adds the missing (`,`) comma in the Packer setup guide which 
breaks the installation if directly copied from the README.

![image](https://github.com/user-attachments/assets/b73ddc1c-fa12-4a5c-a37c-3aac7e4a1c5e)