### PR TITLE
Add support for git worktrees with bare repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Just press the leader_key set on setup and follow you heart. (Is that easy)
   },
   separate_save_and_remove = false, -- if true, will remove the toggle and create the save/remove keymaps.
   leader_key = ";",
-  save_key = "cwd", -- what will be used as root to save the bookmarks. Can be also `git_root`.
+  save_key = "cwd", -- what will be used as root to save the bookmarks. Can be also `git_root` and `git_root_bare`.
   global_bookmarks = false, -- if true, arrow will save files globally (ignores separate_by_branch)
   index_keys = "123456789zxcbnmZXVBNM,afghjklAFGHJKLwrtyuiopWRTYUIOP", -- keys mapped to bookmark index, i.e. 1st bookmark will be accessible by 1, and 12th - by c
   full_path_list = { "update_stuff" } -- filenames on this list will ALWAYS show the file path too.

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -135,7 +135,11 @@ function M.go_to(index)
 		return
 	end
 
-	if config.getState("global_bookmarks") == true or config.getState("save_key_name") == "cwd" then
+	if
+		config.getState("global_bookmarks") == true
+		or config.getState("save_key_name") == "cwd"
+		or config.getState("save_key_name") == "git_root_bare"
+	then
 		vim.cmd(":edit " .. filename)
 	else
 		vim.cmd(":edit " .. config.getState("save_key_cached") .. "/" .. filename)

--- a/lua/arrow/save_keys.lua
+++ b/lua/arrow/save_keys.lua
@@ -14,4 +14,15 @@ function M.git_root()
 	return M.cwd()
 end
 
+function M.git_root_bare()
+	local git_bare_root = vim.fn.system("git rev-parse --path-format=absolute --git-common-dir 2>&1")
+
+	if vim.v.shell_error == 0 then
+		git_bare_root = git_bare_root:gsub("/%.git\n$", "")
+		return git_bare_root:gsub("\n$", "")
+	end
+
+	return M.cwd()
+end
+
 return M

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -341,7 +341,11 @@ function M.openFile(fileNumber)
 
 		closeMenu()
 
-		if config.getState("global_bookmarks") == true or config.getState("save_key_name") == "cwd" then
+		if
+			config.getState("global_bookmarks") == true
+			or config.getState("save_key_name") == "cwd"
+			or config.getState("save_key_name") == "git_root_bare"
+		then
 			action(fileName, vim.b.filename)
 		else
 			action(config.getState("save_key_cached") .. "/" .. fileName, vim.b.filename)

--- a/lua/arrow/utils.lua
+++ b/lua/arrow/utils.lua
@@ -122,8 +122,12 @@ function M.get_buffer_path(bufnr)
 	local escaped_save_key = save_key:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$]", "%%%1")
 
 	if absolute_buffer_path:find("^" .. escaped_save_key .. "/") then
-		local relative_path = absolute_buffer_path:gsub("^" .. escaped_save_key .. "/", "")
-		return relative_path
+		if config.getState("save_key_name") == "git_root_bare" then
+			return vim.fn.fnamemodify(vim.fn.expand("%"), ":~:.")
+		else
+			local relative_path = absolute_buffer_path:gsub("^" .. escaped_save_key .. "/", "")
+			return relative_path
+		end
 	else
 		return absolute_buffer_path
 	end


### PR DESCRIPTION
This PR assumes that the worktree is under the bare repo if not the absolute path will be used.

I am not a 100% sure if this is the right way to do this, but it's been working for me for the last few days.