### PR TITLE
feat: support mini.icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Arrow also provides per buffer bookmarks that will can quickly jump to them. (An
 ```lua
 return {
   "otavioschwanck/arrow.nvim",
+  dependencies = {
+    { "nvim-tree/nvim-web-devicons" },
+    -- or if using `mini.icons`
+    -- { "echasnovski/mini.icons" },
+  },
   opts = {
     show_icons = true,
     leader_key = ';', -- Recommended to be a single key

--- a/lua/arrow/integration/icons.lua
+++ b/lua/arrow/integration/icons.lua
@@ -1,0 +1,37 @@
+local M = {}
+
+local get_icon_from_web_dev_icons = function(file_name)
+	local webdevicons = require("nvim-web-devicons")
+	local extension = vim.fn.fnamemodify(file_name, ":e")
+	local icon, hl_group = webdevicons.get_icon(file_name, extension, { default = true })
+
+	return icon, hl_group
+end
+
+local get_icon_from_mini = function(file_name)
+	local icons = require("mini.icons")
+	return icons.get("extension", file_name)
+end
+
+--- Gets file icon from either `nvim-web-devicons` or `mini.icons`.
+--- @param file_name string
+M.get_file_icon = function(file_name)
+	if vim.fn.isdirectory(file_name) == 1 then
+		return "", "Normal"
+	end
+
+	local use_web_dev_icons = pcall(require, "nvim-web-devicons")
+	local use_mini_icons = pcall(require, "mini.icons")
+
+	if not (use_web_dev_icons or use_mini_icons) then
+		error("No icon provider found", vim.log.levels.ERROR)
+	end
+
+	if use_web_dev_icons then
+		return get_icon_from_web_dev_icons(file_name)
+	end
+
+	return get_icon_from_mini(file_name)
+end
+
+return M

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -4,6 +4,7 @@ local config = require("arrow.config")
 local persist = require("arrow.persist")
 local utils = require("arrow.utils")
 local git = require("arrow.git")
+local icons = require("arrow.integration.icons")
 
 local fileNames = {}
 local to_highlight = {}
@@ -141,21 +142,10 @@ local function closeMenu()
 	vim.api.nvim_win_close(win, true)
 end
 
-local function get_file_icon(file_name)
-	if vim.fn.isdirectory(file_name) == 1 then
-		return "", "Normal"
-	end
-
-	local webdevicons = require("nvim-web-devicons")
-	local extension = vim.fn.fnamemodify(file_name, ":e")
-	local icon, hl_group = webdevicons.get_icon(file_name, extension, { default = true })
-	return icon, hl_group
-end
-
 local function renderBuffer(buffer)
 	vim.api.nvim_buf_set_option(buffer, "modifiable", true)
 
-	local icons = config.getState("show_icons")
+	local show_icons = config.getState("show_icons")
 	local buf = buffer or vim.api.nvim_get_current_buf()
 	local lines = { "" }
 
@@ -185,8 +175,8 @@ local function renderBuffer(buffer)
 			M.openFile(i)
 		end, { noremap = true, silent = true, buffer = buf, nowait = true })
 
-		if icons then
-			local icon, hl_group = get_file_icon(fileNames[i])
+		if show_icons then
+			local icon, hl_group = icons.get_file_icon(fileNames[i])
 
 			to_highlight[i] = hl_group
 


### PR DESCRIPTION
resolves #78 by adding support for [`mini.icons`](https://github.com/echasnovski/mini.icons).

`nvim-web-devicons` is prioritized, followed by `mini.icons`. if no icon provider is found, an error is raised.

also updated the README to specify an icon provider when installing.