### PR TITLE
Use border from config on buffer bookmark windows

### DIFF
--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -64,8 +64,10 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 	local row = height + (index - 1) * (lines_count + 2) - (bookmark_count - 1) * lines_count
 
 	local width = math.ceil(vim.o.columns / 2)
-	
+
 	local zindex = config.getState("buffer_mark_zindex")
+
+	local border = config.getState("window").border
 
 	lastRow = row
 	spawn_col = width
@@ -76,7 +78,7 @@ function M.spawn_preview_window(buffer, index, bookmark, bookmark_count)
 		row = row,
 		col = math.ceil((vim.o.columns - width) / 2),
 		relative = "editor",
-		border = "single",
+		border = border,
 		zindex = zindex or 50,
 	}
 
@@ -305,6 +307,8 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 
 	local width = math.ceil(vim.o.columns / 2)
 
+	local border = config.getState("window").border
+
 	local window_config
 
 	if #bookmarks == 0 then
@@ -315,7 +319,7 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 			col = math.ceil((vim.o.columns - 15) / 2),
 			style = "minimal",
 			relative = "editor",
-			border = "single",
+			border = border,
 		}
 	else
 		window_config = {
@@ -325,7 +329,7 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 			col = width - spawn_col / 2,
 			style = "minimal",
 			relative = "editor",
-			border = "single",
+			border = border,
 		}
 	end
 

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -208,6 +208,8 @@ function M.open_cache_file()
 	local row = math.ceil((vim.o.lines - height) / 2)
 	local col = math.ceil((vim.o.columns - width) / 2)
 
+	local border = config.getState("window").border
+
 	local opts = {
 		style = "minimal",
 		relative = "editor",
@@ -216,7 +218,7 @@ function M.open_cache_file()
 		row = row,
 		col = col,
 		focusable = true,
-		border = "single",
+		border = border,
 	}
 
 	local winid = vim.api.nvim_open_win(bufnr, true, opts)


### PR DESCRIPTION
Solve the issue where buffer bookmark windows were using hardcoded border value instead of making use of the value set on the config