### PR TITLE
fix buffer delete mode not persisting removals

### DIFF
--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -128,7 +128,7 @@ function M.sync_buffer_bookmarks(bufnr)
 			file:write(json.encode(M.local_bookmarks[bufnr]))
 		end
 		file:flush()
-        file:close()
+		file:close()
 
 		M.last_sync_bookmarks[bufnr] = M.local_bookmarks[bufnr]
 		notify()
@@ -159,10 +159,25 @@ function M.remove(index, bufnr)
 		return
 	end
 
-	if M.local_bookmarks[bufnr][index] == nil then
+	local to_remove = {}
+
+	if type(index) == "table" then
+		for _, i in ipairs(index) do
+			if M.local_bookmarks[bufnr][i] ~= nil then
+				table.insert(to_remove, i)
+			end
+		end
+	else
+		to_remove = { index }
+	end
+
+	if #to_remove == 0 then
 		return
 	end
-	table.remove(M.local_bookmarks[bufnr], index)
+
+	for _, i in ipairs(to_remove) do
+		table.remove(M.local_bookmarks[bufnr], i)
+	end
 
 	M.sync_buffer_bookmarks(bufnr)
 end

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -178,9 +178,7 @@ end
 local function delete_marks_from_delete_mode(call_buffer)
 	local reversely_sorted_to_delete = vim.fn.reverse(vim.fn.sort(to_delete))
 
-	for _, index in ipairs(reversely_sorted_to_delete) do
-		persist.remove(index, call_buffer)
-	end
+	persist.remove(reversely_sorted_to_delete, call_buffer)
 end
 
 local function after_close(call_buffer)


### PR DESCRIPTION
I noticed that buffer delete mode does not persist deleting multiple entries when one quits nvim immediately after deleting several bookmarks. In such cases, the plugin will persist deleting only the first entry while retaining the rest.

How to reproduce:
Add several bookmarks (more than 1)
Enter buffer delete mode, delete more than 1 entry
Quit nvim
Open nvim again and open the buffer you deleted the marks on.

You'll notice that only one selected mark was deleted from the cache file.

This PR fixes this issue by making `buffer_persist.remove` take a table (delete_mode) or a single index for other circumstances.