### PR TITLE
Fire events so we can make hooks

### DIFF
--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -213,6 +213,7 @@ local function go_to_bookmark(bookmark)
 	if bookmark.line < top_line or bookmark.line >= top_line + win_height then
 		vim.cmd("normal! zz")
 	end
+	vim.api.nvim_exec_autocmds("User", { pattern = "ArrowGoToBookmark" })
 end
 
 local function toggle_delete_mode(action_buffer)

--- a/lua/arrow/ui.lua
+++ b/lua/arrow/ui.lua
@@ -330,6 +330,7 @@ function M.openFile(fileNumber)
 		end
 
 		closeMenu()
+		vim.api.nvim_exec_autocmds("User", { pattern = "ArrowOpenFile" })
 
 		if
 			config.getState("global_bookmarks") == true


### PR DESCRIPTION
This change adds event firing to the most common actions Arrow performs.

It's a minimally invasive change which allows custom actions. 
Open file -> Open Bookmarks -> Hop within the file

```lua
vim.api.nvim_create_autocmd('User', {
  pattern = 'ArrowOpenFile',
  callback = function(e)
    vim.schedule(function()
      require('arrow.buffer_ui').openMenu(vim.api.nvim_get_current_buf())
    end)
  end,
})
vim.api.nvim_create_autocmd('User', {
  pattern = 'ArrowGoToBookmark',
  callback = function(e)
    vim.schedule(function()
      require('hop').hint_words { multi_windows = false }
    end)
  end,
})
```