### PR TITLE
accepting window value for cache_window

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Just press the leader_key set on setup and follow you heart. (Is that easy)
     col = "auto",
     border = "double",
   },
+  window = { -- control the size of arrow edit window
+    width = 80,
+    height = 10,
+  },
   per_buffer_config = {
     lines = 4, -- Number of lines showed on preview.
     sort_automatically = true, -- Auto sort buffer marks.

--- a/lua/arrow/init.lua
+++ b/lua/arrow/init.lua
@@ -47,7 +47,14 @@ function M.setup(opts)
 		border = "single",
 	}
 
+	local default_cache_window_config = {
+		width = 80,
+		height = 10,
+	}
+
 	config.setState("window", utils.join_two_keys_tables(default_window_config, opts.window or {}))
+
+	config.setState("cache_window", utils.join_two_keys_tables(default_cache_window_config, opts.cache_window or {}))
 
 	config.setState(
 		"per_buffer_config",

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -202,8 +202,10 @@ function M.open_cache_file()
 
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, cache_content)
 
-	local width = math.min(80, vim.fn.winwidth(0) - 4)
-	local height = math.min(20, #cache_content + 2)
+	local cache_window = config.getState("cache_window")
+
+	local width = cache_window.width
+	local height = cache_window.height
 
 	local row = math.ceil((vim.o.lines - height) / 2)
 	local col = math.ceil((vim.o.columns - width) / 2)


### PR DESCRIPTION
my workflow is to open `edit` by default (just like harpoon)

this PR is to allow user to edit the size of edit buffer window. 

for people who work with monorepo, it is normal to have long file path, I want my window to be a lot bigger than the default