### PR TITLE
fix: make buffer ui not modifiable

### DIFF
--- a/lua/arrow/buffer_persist.lua
+++ b/lua/arrow/buffer_persist.lua
@@ -117,6 +117,16 @@ function M.sync_buffer_bookmarks(bufnr)
 
 	local path_dir = vim.fn.fnamemodify(path, ":h")
 
+	local marks = M.local_bookmarks[bufnr]
+
+	if marks == nil or vim.tbl_isempty(marks) then
+		M.last_sync_bookmarks[bufnr] = marks
+		if vim.fn.filereadable(path) == 1 then
+			vim.fn.delete(path)
+		end
+		return false
+	end
+
 	if vim.fn.isdirectory(path_dir) == 0 then
 		vim.fn.mkdir(path_dir, "p")
 	end
@@ -124,13 +134,11 @@ function M.sync_buffer_bookmarks(bufnr)
 	local file = io.open(path, "w")
 
 	if file then
-		if M.local_bookmarks[bufnr] ~= nil and #M.local_bookmarks[bufnr] ~= 0 then
-			file:write(json.encode(M.local_bookmarks[bufnr]))
-		end
+		file:write(json.encode(marks))
 		file:flush()
 		file:close()
 
-		M.last_sync_bookmarks[bufnr] = M.local_bookmarks[bufnr]
+		M.last_sync_bookmarks[bufnr] = marks
 		notify()
 		return true
 	end

--- a/lua/arrow/buffer_ui.lua
+++ b/lua/arrow/buffer_ui.lua
@@ -359,6 +359,8 @@ function M.spawn_action_windows(call_buffer, bookmarks, line_nr, col_nr, call_wi
 
 	vim.api.nvim_buf_set_lines(actions_buffer, 0, -1, false, lines)
 
+	vim.api.nvim_buf_set_option(actions_buffer, "modifiable", false)
+
 	vim.keymap.set("n", config.getState("leader_key"), function()
 		closeMenu(actions_buffer, call_buffer)
 

--- a/lua/arrow/persist.lua
+++ b/lua/arrow/persist.lua
@@ -123,9 +123,17 @@ function M.load_cache_file()
 end
 
 function M.cache_file()
-	local content = vim.fn.join(vim.g.arrow_filenames, "\n")
-	local lines = vim.fn.split(content, "\n")
-	vim.fn.writefile(lines, cache_file_path())
+	local filenames = vim.g.arrow_filenames or {}
+
+	if vim.tbl_isempty(filenames) then
+		local cache_path = cache_file_path()
+		if vim.fn.filereadable(cache_path) == 1 then
+			vim.fn.delete(cache_path)
+		end
+		return
+	end
+
+	vim.fn.writefile(filenames, cache_file_path())
 end
 
 function M.go_to(index)


### PR DESCRIPTION
Right now buffer ui is modifiable, you can paste and delete content into it which I accidentally sometimes do and it's annoying. Not sure if this is the best fix as im still new to nvim and lua